### PR TITLE
Fixed logging to RabbitMQ

### DIFF
--- a/restapi/flask_ext/flask_rabbit.py
+++ b/restapi/flask_ext/flask_rabbit.py
@@ -7,6 +7,15 @@ from restapi.flask_ext import BaseExtension, get_logger
 
 log = get_logger(__name__)
 
+# TODO To be tested: With working RabbitMQ: Does everything
+#       work as intended?
+# TODO To be tested: Reconnection mechanism (e.g. wrong password),
+#      does it try to reconnect several times, then give up?
+# TODO To be tested: dont_connect setting, does it log to file
+#      directly?
+# TODO To be added: Heartbeat mechanism
+# TODO To be added: Close connection - sigint, sigkill
+
 
 '''
 This class provides a (wrapper for a) RabbitMQ connection 
@@ -118,7 +127,7 @@ class RabbitWrapper(object):
             return
 
         # Settings for the message:
-        filter_code = 'de.dkrz.seadata.filter_code.json'
+        filter_code = 'de.dkrz.seadata.filter_code.json' # TODO Add to variables!
         permanent_delivery=2
         props = pika.BasicProperties(
             delivery_mode=permanent_delivery,

--- a/restapi/flask_ext/flask_rabbit.py
+++ b/restapi/flask_ext/flask_rabbit.py
@@ -7,6 +7,7 @@ from restapi.flask_ext import BaseExtension, get_logger
 
 log = get_logger(__name__)
 
+
 '''
 This class provides a (wrapper for a) RabbitMQ connection 
 in order to write log messages into a queue.
@@ -18,20 +19,20 @@ class RabbitExt(BaseExtension):
 
     def custom_connection(self, **kwargs):
 
-        #############################
         # NOTE: for SeaDataCloud
-        # Unused for debugging at the moment
-        # from restapi.confs import PRODUCTION
-        # if not PRODUCTION:
-        if True:
-            log.warning("Skipping Rabbit, logging to normal log instead.")
-            dont_connect = True
-            # TODO: Have a TEST setting for testbeds, with different queue?
-            # TODO: Log into some file if Rabbit not available?
 
-        log.debug('Connecting to the Rabbit')
+        # Only used in production
+        dont_connect = False
+        from restapi.confs import PRODUCTION
+        if not PRODUCTION:
+            dont_connect = True
+            log.warning("Skipping Rabbit, logging to normal log instead.")
+            # TODO: Have a TEST setting for testbeds, with different queue?
+            # TODO: Log into some file if Rabbit not available?        
+
+        log.debug('Creating connection wrapper...')
         conn_wrapper = RabbitWrapper(self.variables, dont_connect)
-        log.debug('Connection wrapper was created, will be passed back.')
+        log.debug('Creating connection wrapper... done.')
         return conn_wrapper
 
 class RabbitWrapper(object):
@@ -100,6 +101,7 @@ class RabbitWrapper(object):
     the messages get logged into the normal log files.
     If the connection is dead, reconnection is attempted,
     but not eternally.
+
     :param dictionary_message: JSON log message
     :param app_name: App name (will be used for the ElasticSearch index name)
     :param exchange: RabbitMQ exchange where the message should be sent
@@ -181,9 +183,11 @@ class RabbitWrapper(object):
                 log.info('RABBIT LOG MESSAGE (%s, %s, %s): %s' % (app_name, exchange, queue, body))
 
 
+
     '''
     Return existing channel (if healthy) or create and
     return new one.
+    
     :return: The channel, or None if connection is switched off.
     :raises: AttributeError if the connection is None.
     '''

--- a/restapi/flask_ext/flask_rabbit.py
+++ b/restapi/flask_ext/flask_rabbit.py
@@ -34,27 +34,20 @@ class RabbitExt(BaseExtension):
 
 
         log.debug('Connecting to the Rabbit')
-        conn_wrapper = RabbitWrapper(self.variables, dont_connect)
+        conn_wrapper = RabbitWrapper(self.variables)
         log.debug('Connection wrapper was created, will be passed back.')
         return conn_wrapper
 
 class RabbitWrapper(object):
 
-    def __init__(self, variables, dont_connect=False):
+    def __init__(self, variables):
         log.debug('Creating RabbitMQ connection wrapper with variables %s' % variables)
         self.__variables = variables
         self.__connection = None
         self.__channel = None
-        self.__dont_connect = dont_connect
-        self.__couldnt_connect = 0
         # TODO: Declare queue and exchange, just in case?
         
         # Initial connection:
-        if self.__dont_connect:
-            log.warn('Will not connect to RabbitMQ (dont_connect = True).')
-            log.debug('Creating RabbitMQ connection wrapper... done. (without connection).')
-            return None
-
         try:
             self.__connect()
             log.debug('Creating RabbitMQ connection wrapper... done. (successful).')
@@ -84,7 +77,6 @@ class RabbitWrapper(object):
                     credentials = credentials
                 )
             )
-            self.__couldnt_connect = 0
             log.info('Connecting to the Rabbit... done.')
 
         except pika.exceptions.AMQPConnectionError as e:
@@ -93,8 +85,109 @@ class RabbitWrapper(object):
             '''
             log.warn('Connecting to the Rabbit... failed (%s)' % e)
             self.__connection = None
-            self.__couldnt_connect = self.__couldnt_connect+1
             raise e
+
+
+
+    '''
+    Send a log message to the RabbitMQ queue, unless
+    the dont-connect parameter is set. In that case,
+    the messages get logged into the normal log files.
+    If the connection is dead, reconnection is attempted,
+    but not eternally.
+    :param dictionary_message: JSON log message
+    :param app_name: App name (will be used for the ElasticSearch index name)
+    :param exchange: RabbitMQ exchange where the message should be sent
+    :param queue: RabbitMQ routing key.
+    '''
+    def log_json_to_queue(self, dictionary_message, app_name, exchange, queue):
+        log.verbose('Asked to log (%s, %s, %s): %s' % (exchange, queue, app_name, dictionary_message))
+        body = json.dumps(dictionary_message)
+
+        # Settings for the message:
+        filter_code = 'de.dkrz.seadata.filter_code.json'
+        permanent_delivery=2
+        props = pika.BasicProperties(
+            delivery_mode=permanent_delivery,
+            headers={'app_name': app_name, 'filter_code': filter_code},
+        )
+
+        # Try sending n times:
+        success = False
+        max_publish = 3
+        e = None
+        for i in range(max_publish):
+            log.verbose('Trying to send message to RabbitMQ in try (%s/%s)' % ((i+1), max_publish))
+
+            try:
+                
+                if self.__connection is None:
+                    self.__connect()
+                elif not self.__connection.is_open:
+                    self.__connect()
+            
+                channel = self.__get_channel()
+                success = channel.basic_publish(
+                    exchange=exchange,
+                    routing_key=queue,
+                    properties=props,
+                    body=body,
+                    mandatory=True
+                )
+                if success:
+                    log.verbose('Succeeded to send message to RabbitMQ in try (%s/%s)' % ((i+1), max_publish))
+                    break
+                else:
+                    log.warn('Log fail without clear reason.')
+                
+            except pika.exceptions.ConnectionClosed as e:
+                # TODO: This happens often. Check if heartbeat solves problem.
+                log.info('Failed to send log message in try (%s/%s), because connection is dead (%s).'
+                    % ((i+1), max_publish, e))
+                self.__connection = None
+                continue
+
+            except pika.exceptions.AMQPConnectionError as e:
+                log.info('Failed to send log message in try (%s/%s) because connection failed (%s).'
+                    % ((i+1), max_publish, e))
+                self.__connection = None
+                continue
+
+            except pika.exceptions.AMQPChannelError as e:
+                log.info('Failed to send log message in try (%s/%s), because channel is dead (%s).'
+                    % ((i+1), max_publish, e))
+                self.__channel = None
+                continue
+
+            except AttributeError as e:
+                log.info('Failed to send log message in try (%s/%s) (%s).' % ((i+1), max_publish, e))
+                self.__connection = None
+                continue
+
+            # If failed each time:
+            if i+1 >= max_publish:
+                log.warning('Could not log to RabbitMQ (%s), logging here instead...' % e)
+                log.info('RABBIT LOG MESSAGE (%s, %s, %s): %s' % (app_name, exchange, queue, body))
+                break
+
+
+    '''
+    Return existing channel (if healthy) or create and
+    return new one.
+    :return: The channel, or None if connection is switched off.
+    :raises: AttributeError if the connection is None.
+    '''
+    def __get_channel(self):
+
+        if self.__channel is None:
+            log.verbose('Creating new channel.')
+            self.__channel = self.__connection.channel()
+
+        elif self.__channel.is_closed or self.__channel.is_closing:
+            log.verbose('Recreating channel.')
+            self.__channel = self.__connection.channel()
+        
+        return self.__channel
 
 
     '''
@@ -102,8 +195,6 @@ class RabbitWrapper(object):
     '''
     def close_connection(self):
         # TODO: This must be called!
-        if self.__dont_connect:
-            return
         if self.__connection.is_closed or self.__connection.is_closing:
             log.debug('Connection already closed or closing.')
         else:

--- a/restapi/flask_ext/flask_rabbit.py
+++ b/restapi/flask_ext/flask_rabbit.py
@@ -18,6 +18,8 @@ class RabbitExt(BaseExtension):
         # if not PRODUCTION:
         if True:
             log.warning("Skipping Rabbit")
+            # TODO: Have a TEST setting for testbeds, with different queue?
+            # TODO: Log into some file if Rabbit not available?
 
             class Empty:
                 pass


### PR DESCRIPTION
This code fixes the logging of messages to a RabbitMQ instance. Broken connections are handled (by reconnecting, but only up to a number of times to avoid eternal reconnections).

This was tested with EUDAT http-api branch 1.0.3 (plus applied updates, see PR #119 in https://github.com/EUDAT-B2STAGE/http-api which I will open in a minute.

Tested:
- Connecting to RabbitMQ instance and sending log messages (e.g. during enable, upload)
- Reconnecting after a connection was closed by peer
- Attempting to reconnect a few times if a connection fails gently e.g. (due to wrong RabbitMQ user password)
- Writing log message into normal log if message delivery failed
